### PR TITLE
Fix credits for template not showing

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -44,6 +44,6 @@
       >Chirpy</a>
     {%- endcapture -%}
 
-    {{ site.meta | replace: ':PLATFORM', _platform | replace: ':THEME', _theme }}
+    {{ site.data.data.meta | replace: ':PLATFORM', _platform | replace: ':THEME', _theme }}
   </p>
 </footer>


### PR DESCRIPTION
The data was not being passed correctly, `site.meta` instead of `site.data.data.meta`. This is necessary as we have different structure for `_data` from the original template.