### PR TITLE
Revert published date to original published date

### DIFF
--- a/_posts/2025-03-21-setting-up-development-environment.md
+++ b/_posts/2025-03-21-setting-up-development-environment.md
@@ -7,7 +7,7 @@ tags:
 - setup
 description: Walking through how we set up Kotlin Multiplatform with Android Studio
   to get started with the development.
-date: 2025-04-01 15:23 +0800
+date: 2025-03-21 22:03 +0800
 ---
 ## Project specifications
 


### PR DESCRIPTION
The original published date was 2025-03-21. The post was published on this date, and the change to 2025-04-01 was a mistake. The latest changes changed the published date to today.